### PR TITLE
add empty folders for entities and dbcontext

### DIFF
--- a/ago-oct-pf-ecommerce-backend/Revenge.API.csproj
+++ b/ago-oct-pf-ecommerce-backend/Revenge.API.csproj
@@ -20,6 +20,8 @@
 
   <ItemGroup>
     <Folder Include="Controllers\" />
+    <Folder Include="Models\Entities\" />
+    <Folder Include="Data\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Se podria añadir una carpeta para los modelos y adentro de este las entidades, asi como una carpeta aparte para el dbContext. Enguel y yo pensamos que asi nos evitariamos cualquier conflicto en caso de que uno cree una carpeta Entities y otro tambien, y asi tambien trabajariamos en carpetas ya creadas, por lo que los cambios no chocarian. 