### PR TITLE
feat: add CODEOWNERS file to automatically assign reviewers to PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Albert2707 @Uriel020 @jaime-hndz


### PR DESCRIPTION
Add CODEOWNERS to avoid manually assigning reviewers for pull requests
